### PR TITLE
Use the same version of the artifact action everywhere.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install build
         python -m build
     - name: Store sdist as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/*.tar.gz
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: 3.12
     - name: Download artifacts produced during the build_wheels and build_sdist jobs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist/


### PR DESCRIPTION
Should fix publishing packages to PyPI.
