### PR TITLE
Only skip optional filters on certain exceptions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy<2",
     "packaging",
     "pandas",
-    "pyarrow",
+    "pyarrow<15",
     "pyspark>=3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ extend-exclude = 'deps\/.*$'
 line_length = 100
 
 [tool.cibuildwheel]
-skip = ["cp3{6,7,8}-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_i686", "*-musllinux_x86_64", "*-musllinux_aarch64"]
+skip = ["cp3{6,7,8,13}-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_i686", "*-musllinux_x86_64", "*-musllinux_aarch64"]
 # MPI needed for testing with mpi4py
 before-all = "yum install -y openmpi3-devel java-11-openjdk"
 environment = { MPICC="/usr/lib64/openmpi3/bin/mpicc" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy<2",
     "packaging",
     "pandas",
-    "pyarrow<15",
+    "pyarrow",
     "pyspark>=3",
 ]
 

--- a/src/functionalizer/core.py
+++ b/src/functionalizer/core.py
@@ -5,9 +5,10 @@ import os
 from pathlib import Path
 
 import pyarrow.parquet as pq
-import sparkmanager as sm
 from fz_td_recipe import Recipe
 from pyspark.sql import functions as F
+
+import sparkmanager as sm
 
 from . import utils
 from .circuit import Circuit

--- a/src/functionalizer/filters/__init__.py
+++ b/src/functionalizer/filters/__init__.py
@@ -1,6 +1,6 @@
 """Module with filters to process edge data."""
 
-from .definitions import DatasetOperation, load  # NOQA
+from .definitions import DatasetOperation, FilterInitializationError, load  # NOQA
 from .helpers import enable_debug  # NOQA
 
 from . import helpers  # NOQA

--- a/src/functionalizer/filters/definitions.py
+++ b/src/functionalizer/filters/definitions.py
@@ -38,6 +38,10 @@ def load(*dirnames: str) -> None:
             importlib.import_module(modulename)
 
 
+class FilterInitializationError(RuntimeError):
+    pass
+
+
 # ---------------------------------------------------
 # Dataset operations
 # ---------------------------------------------------
@@ -108,7 +112,7 @@ class __DatasetOperationType(type):
             )
             try:
                 filters.append(fcls(*args))
-            except Exception as e:
+            except FilterInitializationError as e:
                 if fcls._required:
                     logger.fatal("Could not instantiate %s", fcls.__name__)
                     raise

--- a/src/functionalizer/filters/definitions.py
+++ b/src/functionalizer/filters/definitions.py
@@ -39,7 +39,7 @@ def load(*dirnames: str) -> None:
 
 
 class FilterInitializationError(RuntimeError):
-    pass
+    """Error to be raised when filters should be skipped."""
 
 
 # ---------------------------------------------------

--- a/src/functionalizer/filters/definitions.py
+++ b/src/functionalizer/filters/definitions.py
@@ -11,7 +11,6 @@ from glob import glob
 from pathlib import Path
 
 import sparkmanager as sm
-
 from functionalizer.circuit import Circuit
 from functionalizer.utils import get_logger
 from functionalizer.utils.checkpointing import checkpoint_resume

--- a/src/functionalizer/filters/implementations/reduce_and_cut.py
+++ b/src/functionalizer/filters/implementations/reduce_and_cut.py
@@ -1,8 +1,8 @@
 """Filter that matches distributions of synapses."""
 
-import sparkmanager as sm
 from pyspark.sql import functions as F
 
+import sparkmanager as sm
 from functionalizer.circuit import touches_per_pathway
 from functionalizer.definitions import CheckpointPhases
 from functionalizer.filters import DatasetOperation, helpers

--- a/src/functionalizer/filters/implementations/spine_length.py
+++ b/src/functionalizer/filters/implementations/spine_length.py
@@ -3,9 +3,9 @@
 from operator import attrgetter
 
 import pandas as pd
-import sparkmanager as sm
 from pyspark.sql import functions as F
 
+import sparkmanager as sm
 from functionalizer.filters import DatasetOperation, FilterInitializationError
 from functionalizer.utils import get_logger
 

--- a/src/functionalizer/filters/implementations/spine_length.py
+++ b/src/functionalizer/filters/implementations/spine_length.py
@@ -6,7 +6,7 @@ import pandas as pd
 import sparkmanager as sm
 from pyspark.sql import functions as F
 
-from functionalizer.filters import DatasetOperation
+from functionalizer.filters import DatasetOperation, FilterInitializationError
 from functionalizer.utils import get_logger
 
 from . import add_bin_column, add_random_column
@@ -29,8 +29,11 @@ class SpineLengthFilter(DatasetOperation):
         recipe to obtain the desired distribution of spine lengths to match.
         """
         super().__init__(recipe, source, target)
-        self.seed = recipe.seeds.synapseSeed
+        self.seed = recipe.get("seed")
         logger.info("Using seed %d for spine length adjustment", self.seed)
+
+        if not recipe.get("spine_lengths"):
+            raise FilterInitializationError("'synapse_reposition' not in recipe")
 
         self.binnings = sorted(recipe.spine_lengths, key=attrgetter("length"))
 

--- a/src/functionalizer/filters/implementations/spine_morphologies.py
+++ b/src/functionalizer/filters/implementations/spine_morphologies.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from pyspark.sql import functions as F
 
-from functionalizer.filters import DatasetOperation
+from functionalizer.filters import DatasetOperation, FilterInitializationError
 
 
 class SpineMorphologies(DatasetOperation):
@@ -53,6 +53,10 @@ class SpineMorphologies(DatasetOperation):
     def __init__(self, recipe, source, target):
         """Initializes the filter using the morphology database."""
         super().__init__(recipe, source, target)
+
+        if not target.spine_morphology_path:
+            raise FilterInitializationError("target nodes do not define 'spine_morphologies_dir'")
+
         self._morphologies, self._filter = _create_spine_morphology_udf(
             target.spine_morphology_path
         )
@@ -105,6 +109,7 @@ def _read_spine_morphology_attributes(spine_morpho_path: Path):
     Returns a dataframe with spine morphology properties.
     """
     files = sorted(spine_morpho_path.glob("*.h5"))
+    assert len(files) > 0, "no spine morphologies present"
     ids = np.ndarray((0,), dtype=int)
     lengths = np.ndarray((0,), dtype=float)
     morphologies = np.ndarray((0,), dtype=int)

--- a/src/functionalizer/filters/implementations/synapse_properties.py
+++ b/src/functionalizer/filters/implementations/synapse_properties.py
@@ -1,9 +1,9 @@
 """Filters to add properties to synapses."""
 
-import sparkmanager as sm
 from pyspark.sql import functions as F
 from pyspark.sql import types as T
 
+import sparkmanager as sm
 from functionalizer.filters import DatasetOperation
 from functionalizer.utils import get_logger
 

--- a/src/functionalizer/filters/implementations/synapse_reposition.py
+++ b/src/functionalizer/filters/implementations/synapse_reposition.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import pandas as pd
-import sparkmanager as sm
 
+import sparkmanager as sm
 from functionalizer.filters import DatasetOperation, FilterInitializationError
 
 

--- a/src/functionalizer/filters/implementations/synapse_reposition.py
+++ b/src/functionalizer/filters/implementations/synapse_reposition.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import sparkmanager as sm
 
-from functionalizer.filters import DatasetOperation
+from functionalizer.filters import DatasetOperation, FilterInitializationError
 
 
 class SynapseReposition(DatasetOperation):
@@ -20,6 +20,8 @@ class SynapseReposition(DatasetOperation):
     def __init__(self, recipe, source, target):
         """Initialize the filter, extracting the reposition part of the recipe."""
         super().__init__(recipe, source, target)
+        if not recipe.get("synapse_reposition"):
+            raise FilterInitializationError("'synapse_reposition' not in recipe")
         self.columns, self.reposition = recipe.as_matrix("synapse_reposition")
         self.unset_value = len(recipe.get("synapse_reposition"))
 

--- a/src/functionalizer/filters/implementations/touch.py
+++ b/src/functionalizer/filters/implementations/touch.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 import pandas as pd
-import sparkmanager as sm
 from pyspark.sql import functions as F
 
+import sparkmanager as sm
 from functionalizer.filters import DatasetOperation
 from functionalizer.utils import get_logger
 

--- a/src/functionalizer/io/circuit.py
+++ b/src/functionalizer/io/circuit.py
@@ -9,11 +9,11 @@ from typing import List
 
 import pandas as pd
 import pyarrow.parquet as pq
-import sparkmanager as sm
 from packaging.version import VERSION_PATTERN, Version
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
 
+import sparkmanager as sm
 from functionalizer import schema
 from functionalizer.schema import OUTPUT_MAPPING
 from functionalizer.utils import get_logger

--- a/src/functionalizer/utils/checkpointing.py
+++ b/src/functionalizer/utils/checkpointing.py
@@ -4,8 +4,9 @@ from collections import namedtuple
 from functools import wraps
 from inspect import signature
 
-import sparkmanager as sm
 from pyspark.sql.column import _to_seq
+
+import sparkmanager as sm
 
 from . import get_logger
 from .filesystem import exists, isdir, size

--- a/src/functionalizer/utils/spark.py
+++ b/src/functionalizer/utils/spark.py
@@ -2,8 +2,9 @@
 
 from contextlib import contextmanager
 
-import sparkmanager as sm
 from pyspark.sql import functions as F
+
+import sparkmanager as sm
 
 from . import get_logger
 

--- a/tests/circuit_1000n/circuit_config_invalid.json
+++ b/tests/circuit_1000n/circuit_config_invalid.json
@@ -1,0 +1,31 @@
+{
+   "manifest": {
+      "$BASE_DIR": "./",
+      "$COMPONENT_DIR": "$BASE_DIR",
+      "$NETWORK_DIR": "$BASE_DIR"
+   },
+   "components": {
+      "biophysical_neuron_models_dir": "no comprendo",
+      "provenance": {
+         "bioname_dir": "$COMPONENT_DIR/bioname"
+      }
+   },
+   "networks": {
+      "nodes": [
+         {
+            "nodes_file": "$NETWORK_DIR/nodes.h5",
+            "nodes_types_file": null,
+            "populations": {
+               "All": {
+                  "morphologies_dir": null,
+                  "alternate_morphologies": {
+                     "h5v1": "$BASE_DIR/morphologies/h5"
+                  },
+                  "spine_morphologies_dir": "no comprendo"
+               }
+            }
+         }
+      ],
+      "edges": []
+   }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,16 @@ ARGS = (
     [str(DATADIR / "touches" / "*.parquet")],
 )
 
+DEFAULT_ARGS = {
+    "recipe_file": DATADIR / "recipe.json",
+    "circuit_config": CIRCUIT_CONFIG,
+    "source": None,
+    "source_nodeset": None,
+    "target": None,
+    "target_nodeset": None,
+    "edges": [str(DATADIR / "touches" / "*.parquet")],
+}
+
 filters.load()
 
 
@@ -49,10 +59,11 @@ def circuit_config():
     return CIRCUIT_CONFIG
 
 
-@pytest.fixture(scope="session", name="fz")
-def fz_fixture(tmp_path_factory):
+@pytest.fixture(scope="class", name="fz", params=[{}])
+def fz_fixture(request, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("filters")
-    return create_functionalizer(tmpdir, RM.FUNCTIONAL.value).init_data(*ARGS)
+    kwargs = DEFAULT_ARGS | request.param
+    return create_functionalizer(tmpdir, RM.FUNCTIONAL.value).init_data(**kwargs)
 
 
 @pytest.fixture(scope="session", name="gj")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ More about conftest.py under: https://pytest.org/latest/plugins.html
 from pathlib import Path
 
 import pytest
+
 from functionalizer import filters
 from functionalizer.core import Functionalizer
 from functionalizer.definitions import RunningMode as RM

--- a/tests/test_data_input_nodes.py
+++ b/tests/test_data_input_nodes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from conftest import DATADIR, create_functionalizer
+
 from functionalizer.io import NodeData
 
 

--- a/tests/test_data_input_parquet.py
+++ b/tests/test_data_input_parquet.py
@@ -3,6 +3,7 @@
 import numpy
 import pandas as pd
 import pytest
+
 import sparkmanager as sm
 from functionalizer.io.circuit import BRANCH_COLUMNS, EdgeData
 from functionalizer.utils.conf import Configuration

--- a/tests/test_data_input_sonata.py
+++ b/tests/test_data_input_sonata.py
@@ -6,7 +6,7 @@ import h5py
 import numpy
 import pytest
 import sparkmanager as sm
-from conftest import DEFAULT_ARGS, DATADIR, create_functionalizer
+from conftest import DATADIR, DEFAULT_ARGS, create_functionalizer
 from functionalizer.io.circuit import BRANCH_COLUMNS, EdgeData
 from functionalizer.utils.conf import Configuration
 

--- a/tests/test_data_input_sonata.py
+++ b/tests/test_data_input_sonata.py
@@ -5,8 +5,9 @@ import os
 import h5py
 import numpy
 import pytest
-import sparkmanager as sm
 from conftest import DATADIR, DEFAULT_ARGS, create_functionalizer
+
+import sparkmanager as sm
 from functionalizer.io.circuit import BRANCH_COLUMNS, EdgeData
 from functionalizer.utils.conf import Configuration
 

--- a/tests/test_data_input_sonata.py
+++ b/tests/test_data_input_sonata.py
@@ -6,7 +6,7 @@ import h5py
 import numpy
 import pytest
 import sparkmanager as sm
-from conftest import ARGS, DATADIR, create_functionalizer
+from conftest import DEFAULT_ARGS, DATADIR, create_functionalizer
 from functionalizer.io.circuit import BRANCH_COLUMNS, EdgeData
 from functionalizer.utils.conf import Configuration
 
@@ -54,9 +54,8 @@ def test_branch_shift(edges_w_branch_type):
 @pytest.mark.slow
 def test_sonata_properties(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("sonata_properties")
-    fz = create_functionalizer(tmpdir, ["SynapseProperties"]).init_data(
-        *ARGS[:-1], edges=(os.path.join(DATADIR, "edges.h5"), "default")
-    )
+    kwargs = DEFAULT_ARGS | {"edges": (os.path.join(DATADIR, "edges.h5"), "default")}
+    fz = create_functionalizer(tmpdir, ["SynapseProperties"]).init_data(**kwargs)
     fz.process_filters()
 
     assert "delay" in fz.circuit.df.columns

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pyspark.sql.functions as F
 import pytest
 import sparkmanager as sm
-from conftest import DEFAULT_ARGS, DATADIR, create_functionalizer
+from conftest import DATADIR, DEFAULT_ARGS, create_functionalizer
 from functionalizer.utils.spark import cache_broadcast_single_part
 
 NUM_AFTER_DISTANCE = 226301
@@ -57,16 +57,12 @@ class TestFilterInitialization:
 class TestBogusFilterInitialization:
     """Test initialization of optional filters"""
 
-    @pytest.mark.parametrize("fz", [{"circuit_config": DATADIR / "circuit_config_invalid.json"}], indirect=True)
+    @pytest.mark.parametrize(
+        "fz", [{"circuit_config": DATADIR / "circuit_config_invalid.json"}], indirect=True
+    )
     def test_spine_morphos(self, fz):
         with pytest.raises(AssertionError):
             fz.process_filters(filters=["SpineMorphologies"])
-
-class TestFilterInitialization:
-    """Test initialization of optional filters"""
-
-    def test_spine_morphos(self, fz):
-        fz.process_filters(filters=["SpineMorphologies"])
 
 
 @pytest.mark.slow

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -67,7 +67,6 @@ class TestFilterInitialization:
 
     def test_spine_morphos(self, fz):
         fz.process_filters(filters=["SpineMorphologies"])
-        fz.process_filters(filters=["SpineMorphologies"])
 
 
 @pytest.mark.slow

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,8 +3,9 @@
 import pandas as pd
 import pyspark.sql.functions as F
 import pytest
-import sparkmanager as sm
 from conftest import DATADIR, DEFAULT_ARGS, create_functionalizer
+
+import sparkmanager as sm
 from functionalizer.utils.spark import cache_broadcast_single_part
 
 NUM_AFTER_DISTANCE = 226301

--- a/tests/test_gap_junctions.py
+++ b/tests/test_gap_junctions.py
@@ -4,8 +4,9 @@ import copy
 
 import numpy as np
 import pytest
-from functionalizer.filters import DatasetOperation
 from pyspark.sql import functions as F
+
+from functionalizer.filters import DatasetOperation
 
 # (src, dst), num_connections
 DENDRO_DATA = [

--- a/tests/test_morpho_shift.py
+++ b/tests/test_morpho_shift.py
@@ -4,11 +4,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from fz_td_recipe import Recipe
+
 import sparkmanager as sm
 from functionalizer.circuit import Circuit
 from functionalizer.schema import LEGACY_MAPPING
 from functionalizer.utils.conf import Configuration
-from fz_td_recipe import Recipe
 
 
 class MockLoader:

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy
 import pytest
+
 from functionalizer.io.morphologies import MorphologyDB
 
 BRANCHES = [

--- a/tests/test_property_generation.py
+++ b/tests/test_property_generation.py
@@ -3,10 +3,11 @@
 from pathlib import Path
 
 import pytest
-import sparkmanager as sm
 from conftest import CIRCUIT_CONFIG, DATADIR
-from functionalizer.filters import DatasetOperation
 from fz_td_recipe import Recipe
+
+import sparkmanager as sm
+from functionalizer.filters import DatasetOperation
 
 
 @pytest.mark.slow

--- a/tests/test_spine_morphology.py
+++ b/tests/test_spine_morphology.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+
 from functionalizer.filters.implementations.spine_morphologies import (
     _create_spine_morphology_udf,
     _read_spine_morphology_attributes,


### PR DESCRIPTION
We currently skip filters that are not required when they raise an
exception during instantiation.  This sometimes masks underlying issues
with the configuration or data - this changes the behavior to only skip
filters if certain exceptions are raised.
